### PR TITLE
feat(e-lab): close applications

### DIFF
--- a/src/components/e-lab/ApplicationCta.tsx
+++ b/src/components/e-lab/ApplicationCta.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+
+import { eLabApplicationCopy, eLabConfig } from "@/config/e-lab";
+import { cn } from "@/lib/utils";
+
+type ELabApplicationCtaProps = {
+  children: ReactNode;
+  className: string;
+  disabledClassName?: string;
+};
+
+export function ELabApplicationCta({
+  children,
+  className,
+  disabledClassName = "cursor-not-allowed opacity-90",
+}: ELabApplicationCtaProps) {
+  if (eLabConfig.applicationsOpen) {
+    return (
+      <a
+        href={eLabConfig.applicationUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={eLabApplicationCopy.ariaLabel}
+        className={className}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      disabled
+      aria-label={eLabApplicationCopy.ariaLabel}
+      className={cn(className, disabledClassName)}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/e-lab/ApplicationCta.tsx
+++ b/src/components/e-lab/ApplicationCta.tsx
@@ -6,14 +6,20 @@ import { cn } from "@/lib/utils";
 type ELabApplicationCtaProps = {
   children: ReactNode;
   className: string;
-  disabledClassName?: string;
+  openClassName: string;
+  closedClassName: string;
 };
 
 export function ELabApplicationCta({
   children,
   className,
-  disabledClassName = "cursor-not-allowed opacity-90",
+  openClassName,
+  closedClassName,
 }: ELabApplicationCtaProps) {
+  const stateClassName = eLabConfig.applicationsOpen
+    ? openClassName
+    : closedClassName;
+
   if (eLabConfig.applicationsOpen) {
     return (
       <a
@@ -21,7 +27,7 @@ export function ELabApplicationCta({
         target="_blank"
         rel="noopener noreferrer"
         aria-label={eLabApplicationCopy.ariaLabel}
-        className={className}
+        className={cn(className, stateClassName)}
       >
         {children}
       </a>
@@ -29,13 +35,13 @@ export function ELabApplicationCta({
   }
 
   return (
-    <button
-      type="button"
-      disabled
+    <span
+      role="status"
+      aria-disabled="true"
       aria-label={eLabApplicationCopy.ariaLabel}
-      className={cn(className, disabledClassName)}
+      className={cn(className, "select-none", stateClassName)}
     >
       {children}
-    </button>
+    </span>
   );
 }

--- a/src/config/e-lab.ts
+++ b/src/config/e-lab.ts
@@ -1,0 +1,45 @@
+type ELabConfig = {
+  currentIteration: string;
+  applicationsOpen: boolean;
+  applicationUrl: string;
+  heroLogo: {
+    src: string;
+    alt: string;
+  };
+};
+
+export const eLabConfig: ELabConfig = {
+  /**
+   * Update this when the next E-Lab cohort launches, e.g. "6.0".
+   * If the cohort logo changes, update heroLogo at the same time.
+   */
+  currentIteration: "5.0",
+  /** Toggle this when applications open or close. */
+  applicationsOpen: false,
+  applicationUrl: "https://tally.so/r/44KJYb",
+  heroLogo: {
+    src: "/assets/e-lab/E-Lab5Logo.svg",
+    alt: "E-LAB 5.0",
+  },
+};
+
+const cohortName = `E-Lab ${eLabConfig.currentIteration}`;
+
+export const eLabApplicationCopy = {
+  cohortName,
+  heroCtaLabel: eLabConfig.applicationsOpen
+    ? `${cohortName} - Apply Now!`
+    : `${cohortName} - Applications Closed`,
+  cardHeading: eLabConfig.applicationsOpen
+    ? `Application for ${cohortName} is open!`
+    : `Applications for ${cohortName} are closed!`,
+  cardDescription: eLabConfig.applicationsOpen
+    ? "Secure your spot in one of Europe’s leading AI incubators and join a network of top founders, mentors, and investors."
+    : "Applications for this cohort are now closed. Follow TUM.ai for the next intake and upcoming founder opportunities.",
+  cardCtaLabel: eLabConfig.applicationsOpen
+    ? "Apply Now!"
+    : "Applications Closed",
+  ariaLabel: eLabConfig.applicationsOpen
+    ? `Apply for ${cohortName}`
+    : `${cohortName} applications are closed`,
+} as const;

--- a/src/views/headerPages/e-lab/ELab.tsx
+++ b/src/views/headerPages/e-lab/ELab.tsx
@@ -1,9 +1,11 @@
 import JsonLd from "@/components/JsonLd";
+import { ELabApplicationCta } from "@/components/e-lab/ApplicationCta";
 import { ExpectationELab } from "@/components/e-lab/ExpectationELab";
 import { NotableStartups } from "@/components/e-lab/NotableStartups";
 import { Testimonials } from "@/components/e-lab/Testimonials";
 import { Timeline } from "@/components/e-lab/TimeLine";
 import FAQ from "@/components/ui/FAQ";
+import { eLabApplicationCopy } from "@/config/e-lab";
 import { faq } from "@/data/e-lab/FAQ";
 import type { Organization, WithContext } from "schema-dts";
 import { Hero } from "./hero";
@@ -93,15 +95,13 @@ export default function ELab() {
                       className={`mb-5 text-3xl md:text-4xl font-bold text-black`}
                     >
                       <style></style>
-                      Application for E-Lab 5.0 is open!
+                      {eLabApplicationCopy.cardHeading}
                     </h2>
 
                     <p
                       className={`mx-auto mb-10 max-w-2xl text-base leading-relaxed text-slate-700`}
                     >
-                      Secure your spot in one of Europe’s leading AI incubators
-                      and join a network of top founders, mentors, and
-                      investors.
+                      {eLabApplicationCopy.cardDescription}
                     </p>
 
                     <div className="flex justify-center">
@@ -111,17 +111,10 @@ export default function ELab() {
 
                         {/* Sparkling effects - always visible */}
 
-                        <a
-                          href="https://tally.so/r/44KJYb"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className={
-                            `group relative inline-flex items-center justify-center overflow-hidden rounded-2xl px-6 py-3 text-base font-semibold text-white shadow-xl 
+                        <ELabApplicationCta
+                          className={`group relative inline-flex items-center justify-center overflow-hidden rounded-2xl px-6 py-3 text-base font-semibold text-white shadow-xl 
                           bg-[linear-gradient(135deg,#7C3AED_0%,#A855F7_33%,#EC4899_66%,#6366F1_100%)] bg-[length:200%_200%] bg-[position:0%_50%] 
-                          `
-                            // hover:bg-[position:100%_50%]
-                            // transition-[background-position,transform] duration-500 ease-out hover:scale-[1.02]
-                          }
+                          `}
                         >
                           {/* Soft glow behind button */}
                           <div className="pointer-events-none absolute -inset-x-8 -bottom-6 h-16 rounded-full bg-gradient-to-r from-purple-500/40 via-fuchsia-500/40 to-indigo-500/40 blur-2xl"></div>
@@ -132,7 +125,7 @@ export default function ELab() {
                             // transition-opacity duration-300 group-hover:opacity-100"
                           ></div>
                           <span className="relative z-10 flex items-center gap-2">
-                            <span>Apply Now!</span>
+                            <span>{eLabApplicationCopy.cardCtaLabel}</span>
                             {/* <svg */}
                             {/*   className="h-5 w-5 transition-transform duration-300 group-hover:translate-x-1" */}
                             {/*   fill="none" */}
@@ -147,7 +140,7 @@ export default function ELab() {
                             {/*   /> */}
                             {/* </svg> */}
                           </span>
-                        </a>
+                        </ELabApplicationCta>
                       </div>
                     </div>
                   </div>

--- a/src/views/headerPages/e-lab/ELab.tsx
+++ b/src/views/headerPages/e-lab/ELab.tsx
@@ -5,7 +5,7 @@ import { NotableStartups } from "@/components/e-lab/NotableStartups";
 import { Testimonials } from "@/components/e-lab/Testimonials";
 import { Timeline } from "@/components/e-lab/TimeLine";
 import FAQ from "@/components/ui/FAQ";
-import { eLabApplicationCopy } from "@/config/e-lab";
+import { eLabApplicationCopy, eLabConfig } from "@/config/e-lab";
 import { faq } from "@/data/e-lab/FAQ";
 import type { Organization, WithContext } from "schema-dts";
 import { Hero } from "./hero";
@@ -106,10 +106,9 @@ export default function ELab() {
 
                     <div className="flex justify-center">
                       <div className="relative">
-                        {/* Radiating glow effect - always visible */}
-                        <div className="absolute -inset-2 bg-gradient-to-r from-purple-600 to-indigo-600 rounded-lg opacity-50 blur-xl"></div>
-
-                        {/* Sparkling effects - always visible */}
+                        {eLabConfig.applicationsOpen ? (
+                          <div className="absolute -inset-2 rounded-lg bg-gradient-to-r from-[#9A64D9] to-[#523573] opacity-45 blur-xl" />
+                        ) : null}
 
                         <ELabApplicationCta
                           className="inline-flex items-center justify-center rounded-2xl px-6 py-3 text-base font-semibold transition-colors duration-200 ease-out"

--- a/src/views/headerPages/e-lab/ELab.tsx
+++ b/src/views/headerPages/e-lab/ELab.tsx
@@ -112,34 +112,11 @@ export default function ELab() {
                         {/* Sparkling effects - always visible */}
 
                         <ELabApplicationCta
-                          className={`group relative inline-flex items-center justify-center overflow-hidden rounded-2xl px-6 py-3 text-base font-semibold text-white shadow-xl 
-                          bg-[linear-gradient(135deg,#7C3AED_0%,#A855F7_33%,#EC4899_66%,#6366F1_100%)] bg-[length:200%_200%] bg-[position:0%_50%] 
-                          `}
+                          className="inline-flex items-center justify-center rounded-2xl px-6 py-3 text-base font-semibold transition-colors duration-200 ease-out"
+                          openClassName="bg-[#9A64D9] text-white shadow-xl shadow-[#9A64D9]/25 hover:bg-[#523573]"
+                          closedClassName="bg-[#523573] text-[#F5EFFF] ring-1 ring-[#9A64D9]/25 shadow-lg shadow-[#1B0049]/15"
                         >
-                          {/* Soft glow behind button */}
-                          <div className="pointer-events-none absolute -inset-x-8 -bottom-6 h-16 rounded-full bg-gradient-to-r from-purple-500/40 via-fuchsia-500/40 to-indigo-500/40 blur-2xl"></div>
-                          {/* Border and shine */}
-                          <div className="absolute inset-0 rounded-2xl ring-1 ring-white/30"></div>
-                          <div
-                            className="absolute inset-0 rounded-2xl bg-[radial-gradient(ellipse_at_top_left,_rgba(255,255,255,0.35),_transparent_60%)] opacity-0"
-                            // transition-opacity duration-300 group-hover:opacity-100"
-                          ></div>
-                          <span className="relative z-10 flex items-center gap-2">
-                            <span>{eLabApplicationCopy.cardCtaLabel}</span>
-                            {/* <svg */}
-                            {/*   className="h-5 w-5 transition-transform duration-300 group-hover:translate-x-1" */}
-                            {/*   fill="none" */}
-                            {/*   viewBox="0 0 24 24" */}
-                            {/*   stroke="currentColor" */}
-                            {/* > */}
-                            {/*   <path */}
-                            {/*     strokeLinecap="round" */}
-                            {/*     strokeLinejoin="round" */}
-                            {/*     strokeWidth={2} */}
-                            {/*     d="M14 5l7 7m0 0l-7 7m7-7H3" */}
-                            {/*   /> */}
-                            {/* </svg> */}
-                          </span>
+                          {eLabApplicationCopy.cardCtaLabel}
                         </ELabApplicationCta>
                       </div>
                     </div>

--- a/src/views/headerPages/e-lab/hero.tsx
+++ b/src/views/headerPages/e-lab/hero.tsx
@@ -78,31 +78,12 @@ export const Hero = () => {
 
             {/* CTA Button */}
             <div className="pt-1">
-              <ELabApplicationCta className="group relative inline-flex items-center justify-center px-7 py-2 text-base font-normal text-white transition-all duration-300 ease-out">
-                <div
-                  className="absolute inset-0 rounded-full bg-gradient-to-r from-purple-600 to-purple-500 shadow-lg shadow-purple-500/25 transition-all duration-300 "
-                  // group-hover:shadow-purple-500/40 group-hover:scale-105"
-                ></div>
-                <div
-                  className="absolute inset-0 rounded-full bg-gradient-to-r from-purple-500 to-purple-400 opacity-0 transition-opacity duration-300 "
-                  // group-hover:opacity-100"
-                ></div>
-                <span className="relative flex items-center space-x-2">
-                  <span>{eLabApplicationCopy.heroCtaLabel}</span>
-                  {/* <svg */}
-                  {/*   className="w-4 h-4 transform transition-transform group-hover:translate-x-1" */}
-                  {/*   fill="none" */}
-                  {/*   stroke="currentColor" */}
-                  {/*   viewBox="0 0 24 24" */}
-                  {/* > */}
-                  {/*   <path */}
-                  {/*     strokeLinecap="round" */}
-                  {/*     strokeLinejoin="round" */}
-                  {/*     strokeWidth={2} */}
-                  {/*     d="M17 8l4 4m0 0l-4 4m4-4H3" */}
-                  {/*   /> */}
-                  {/* </svg> */}
-                </span>
+              <ELabApplicationCta
+                className="inline-flex items-center justify-center rounded-full px-7 py-2 text-base font-medium transition-colors duration-200 ease-out"
+                openClassName="bg-[#9A64D9] text-white shadow-lg shadow-[#9A64D9]/25 hover:bg-[#523573]"
+                closedClassName="bg-[#523573]/75 text-[#F5EFFF] ring-1 ring-[#9A64D9]/35 shadow-lg shadow-[#1B0049]/30"
+              >
+                {eLabApplicationCopy.heroCtaLabel}
               </ELabApplicationCta>
             </div>
           </div>

--- a/src/views/headerPages/e-lab/hero.tsx
+++ b/src/views/headerPages/e-lab/hero.tsx
@@ -1,3 +1,6 @@
+import { ELabApplicationCta } from "@/components/e-lab/ApplicationCta";
+import { eLabApplicationCopy, eLabConfig } from "@/config/e-lab";
+
 export const Hero = () => {
   return (
     <section className="relative h-screen bg-gradient-to-br from-gray-900 via-purple-900 to-black overflow-hidden">
@@ -38,8 +41,8 @@ export const Hero = () => {
                 <div className="flex justify-center">
                   <div className="h-28 md:h-40 flex items-center">
                     <img
-                      src="/assets/e-lab/E-Lab5Logo.svg"
-                      alt="E-LAB 5.0"
+                      src={eLabConfig.heroLogo.src}
+                      alt={eLabConfig.heroLogo.alt}
                       width={400}
                       height={160}
                       className="h-28 md:h-40 w-auto object-contain"
@@ -75,12 +78,7 @@ export const Hero = () => {
 
             {/* CTA Button */}
             <div className="pt-1">
-              <a
-                href="https://tally.so/r/44KJYb"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="group relative inline-flex items-center justify-center px-7 py-2 text-base font-normal text-white transition-all duration-300 ease-out"
-              >
+              <ELabApplicationCta className="group relative inline-flex items-center justify-center px-7 py-2 text-base font-normal text-white transition-all duration-300 ease-out">
                 <div
                   className="absolute inset-0 rounded-full bg-gradient-to-r from-purple-600 to-purple-500 shadow-lg shadow-purple-500/25 transition-all duration-300 "
                   // group-hover:shadow-purple-500/40 group-hover:scale-105"
@@ -90,7 +88,7 @@ export const Hero = () => {
                   // group-hover:opacity-100"
                 ></div>
                 <span className="relative flex items-center space-x-2">
-                  <span>E-Lab 5.0 - Apply Now!</span>
+                  <span>{eLabApplicationCopy.heroCtaLabel}</span>
                   {/* <svg */}
                   {/*   className="w-4 h-4 transform transition-transform group-hover:translate-x-1" */}
                   {/*   fill="none" */}
@@ -105,7 +103,7 @@ export const Hero = () => {
                   {/*   /> */}
                   {/* </svg> */}
                 </span>
-              </a>
+              </ELabApplicationCta>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add a central E-Lab config for current iteration, application status, form URL, and hero logo
- switch E-Lab CTAs from the Tally form link to disabled closed-state buttons when applicationsOpen is false
- derive hero/card copy from the config so E-Lab 6.0 and future cohorts only require config updates

## Testing
- pnpm verify