### PR TITLE
feat(sanity): add staging draft preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,24 @@ The app reads these environment variables to connect to the CMS:
 
 - `NEXT_PUBLIC_SANITY_PROJECT_ID`
 - `NEXT_PUBLIC_SANITY_DATASET`
+- `SANITY_API_READ_TOKEN` for draft preview and live draft updates
 
 If the values are missing, the Sanity fetchers may fail to return data.
+
+## CMS Staging And Draft Preview
+
+Use a Vercel Preview deployment as the staging environment for CMS changes.
+Configure `SANITY_API_READ_TOKEN` in Vercel Preview/development environments so
+Sanity Presentation can enable Draft Mode without exposing drafts on the public
+published site.
+
+Preview flow:
+
+1. Open `/studio` on the staging deployment.
+2. Use the Presentation tool.
+3. The tool calls `/api/draft-mode/enable`, loads the current deployment in the
+   iframe, and the website reads Sanity's draft perspective.
+4. Draft changes refresh in real time through Sanity Live before publishing.
 
 ## How The App Is Structured
 
@@ -76,7 +92,7 @@ If the values are missing, the Sanity fetchers may fail to return data.
 - `src/components/` holds reusable sections and shared UI primitives.
 - `src/data/` holds static copy and curated data arrays.
 - `src/sanity/` holds the CMS configuration and TypeScript schema definitions.
-- `src/lib/` holds utilities, redirects, security helpers, shared types, and cached Sanity GROQ fetchers.
+- `src/lib/` holds utilities, redirects, security helpers, shared types, and Sanity Live fetchers.
 
 Three pages currently fetch live Sanity data on the server:
 
@@ -96,11 +112,11 @@ If you need to:
 
 - add or change a route: start in `src/app/`, then connect it to a view in `src/views/`
 - update static page copy: check `src/data/` first, then the matching component
-- change events, partners, or research data: visit `/studio` locally or in production
+- change events, partners, or research data: visit `/studio` locally or on the staging deployment
 - change global nav, footer, or font setup: edit `src/app/layout.tsx`, `src/components/Header.tsx`, `src/components/Footer.tsx`
 - change shared styling or tokens: edit `src/styles/index.css`
 - change SEO or JSON-LD: edit `src/config/seo.ts`
-- change CMS field mapping or add tables: edit schemas in `src/sanity/schemas/`, then update the GROQ queries in `src/lib/sanity.ts`
+- change CMS field mapping or add tables: edit schemas in `src/sanity/schemas/`, then update the GROQ queries in `src/lib/sanity-queries.ts`
 
 One important legacy file remains:
 

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -77,6 +77,7 @@ Important:
 
 - `/events`, `/research`, and `/partners` render from server-side calls to `src/lib/sanity.ts`
 - the API routes mirror that data, but they are not the primary rendering path
+- draft preview uses `/studio` -> Presentation -> `/api/draft-mode/enable`; keep `SANITY_API_READ_TOKEN` configured in staging/preview environments when testing drafts
 
 ### Add or change a JSON endpoint
 

--- a/docs/repo-structure.md
+++ b/docs/repo-structure.md
@@ -115,14 +115,14 @@ Examples:
 
 `src/sanity/` is the source of truth for dynamic content structure.
 
-- `sanity.config.ts`: Main Studio configuration file.
+- `sanity.config.ts`: Main Studio configuration file, including the Presentation preview setup.
 - `schemas/`: Contains the TypeScript definitions for database models (e.g., `event.ts`, `partner.ts`, `research.ts`).
 
 ### `src/lib/`
 
 `src/lib/` contains shared runtime helpers:
 
-- `sanity.ts` contains the Sanity client and GROQ queries wrapped in `unstable_cache`
+- `sanity.ts` contains the Sanity client, Sanity Live wiring, and draft-aware fetch helpers
 - `types.ts` re-exports shared data types and local UI types
 - `utils.ts` contains event filtering/grouping helpers and class merging
 - `security.ts` sanitizes URLs and JSON-LD output
@@ -149,8 +149,8 @@ If a contributor only edits `src/app/globals.css`, they will miss most of the ac
 
 Sanity-backed data currently follows this path:
 
-1. `src/lib/sanity.ts` defines GROQ queries to fetch data from the Sanity API.
-2. The fetchers in `src/lib/sanity.ts` wrap the client calls in Next.js `unstable_cache`.
+1. `src/lib/sanity-queries.ts` defines GROQ queries to fetch data from the Sanity API.
+2. The fetchers in `src/lib/sanity.ts` call Sanity Live's `sanityFetch`.
 3. server routes consume those helpers directly:
    - `/events` uses `getSanityEvents()`
    - `/research` uses `getSanityResearchProjects()`
@@ -164,6 +164,13 @@ Important contributor note:
 
 - the page routes fetch from `src/lib/sanity.ts` directly
 - changing an API handler alone will not change page behavior unless the page actually consumes that handler
+
+Draft preview flow:
+
+1. `/studio` loads the Sanity Presentation tool.
+2. Presentation calls `/api/draft-mode/enable` with a Sanity preview secret.
+3. Draft Mode switches the website to Sanity's draft perspective.
+4. `<SanityLive />` refreshes the rendered page when the CMS changes.
 
 ## Tests
 

--- a/src/app/api/draft-mode/enable/route.ts
+++ b/src/app/api/draft-mode/enable/route.ts
@@ -1,0 +1,6 @@
+import { client } from "@/lib/sanity";
+import { defineEnableDraftMode } from "next-sanity/draft-mode";
+
+export const { GET } = defineEnableDraftMode({
+  client: client.withConfig({ token: process.env.SANITY_API_READ_TOKEN }),
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,10 @@
 import Footer from "@/components/Footer";
 import { Header } from "@/components/Header";
+import { SanityLive, isSanityConfigured } from "@/lib/sanity";
 import type { Metadata } from "next";
+import { VisualEditing } from "next-sanity/visual-editing";
 import localFont from "next/font/local";
+import { draftMode } from "next/headers";
 import "../styles/index.css";
 
 const manrope = localFont({
@@ -25,17 +28,21 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const { isEnabled: isDraftMode } = await draftMode();
+
   return (
     <html lang="en">
       <body className={manrope.variable}>
         <Header />
         {children}
         <Footer />
+        {isSanityConfigured ? <SanityLive includeDrafts={isDraftMode} /> : null}
+        {isDraftMode ? <VisualEditing /> : null}
       </body>
     </html>
   );

--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -1,52 +1,81 @@
 import "server-only";
 
 import { createClient } from "next-sanity";
-import { unstable_cache } from "next/cache";
+import {
+  type LivePerspective,
+  defineLive,
+  resolvePerspectiveFromCookies,
+} from "next-sanity/live";
+import { cookies, draftMode } from "next/headers";
 import { EVENTS_QUERY, PARTNERS_QUERY, RESEARCH_QUERY } from "./sanity-queries";
 import type { Event, Partner, Research } from "./types";
 
+const projectId =
+  process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "test-project-id";
+const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET || "production";
+const apiVersion = "2024-03-01";
+const readToken = process.env.SANITY_API_READ_TOKEN;
+
+export const isSanityConfigured = Boolean(
+  process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
+);
+
 export const client = createClient({
-  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "test-project-id",
-  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || "production",
-  apiVersion: "2024-03-01",
-  useCdn: false,
+  projectId,
+  dataset,
+  apiVersion,
+  useCdn: true,
+  perspective: "published",
+  stega: {
+    studioUrl: "/studio",
+  },
 });
 
+export const { sanityFetch, SanityLive } = defineLive({
+  client,
+  serverToken: readToken || false,
+  browserToken: readToken || false,
+});
+
+async function getFetchOptions(): Promise<{
+  perspective: LivePerspective;
+  stega: boolean;
+}> {
+  const { isEnabled } = await draftMode();
+
+  if (!isEnabled || !readToken) {
+    return { perspective: "published", stega: false };
+  }
+
+  const perspective = await resolvePerspectiveFromCookies({
+    cookies: await cookies(),
+  });
+
+  return {
+    perspective: perspective ?? "drafts",
+    stega: true,
+  };
+}
+
+async function fetchSanityList<T>(query: string, tags: string[]): Promise<T[]> {
+  if (!isSanityConfigured) {
+    return [];
+  }
+
+  const { perspective, stega } = await getFetchOptions();
+  const { data } = await sanityFetch({ query, perspective, stega, tags });
+
+  return Array.isArray(data) ? (data as T[]) : [];
+}
+
 export async function getSanityResearchProjects(): Promise<Research[]> {
-  return unstable_cache(
-    async () =>
-      process.env.NEXT_PUBLIC_SANITY_PROJECT_ID
-        ? client.fetch(RESEARCH_QUERY)
-        : [],
-    ["sanity-research-projects"],
-    { revalidate: 900, tags: ["research-projects"] },
-  )();
+  return fetchSanityList<Research>(RESEARCH_QUERY, ["research-projects"]);
 }
 
 export async function getSanityEvents(): Promise<Event[]> {
-  return unstable_cache(
-    async () =>
-      process.env.NEXT_PUBLIC_SANITY_PROJECT_ID
-        ? client.fetch(EVENTS_QUERY)
-        : [],
-    ["sanity-events"],
-    {
-      revalidate: 300,
-      tags: ["events"],
-    },
-  )();
+  return fetchSanityList<Event>(EVENTS_QUERY, ["events"]);
 }
 
 export async function getSanityPartners(): Promise<Partner[]> {
-  return unstable_cache(
-    async () =>
-      process.env.NEXT_PUBLIC_SANITY_PROJECT_ID
-        ? client.fetch(PARTNERS_QUERY)
-        : [],
-    ["sanity-partners"],
-    {
-      revalidate: 900,
-      tags: ["partners"],
-    },
-  )();
+  return fetchSanityList<Partner>(PARTNERS_QUERY, ["partners"]);
 }

--- a/src/sanity/sanity.config.ts
+++ b/src/sanity/sanity.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "sanity";
+import { presentationTool } from "sanity/presentation";
 import { structureTool } from "sanity/structure";
 import { schema } from "./schemas";
 
@@ -8,5 +9,15 @@ export default defineConfig({
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || "production",
   title: "Website Content",
   schema,
-  plugins: [structureTool()],
+  plugins: [
+    structureTool(),
+    presentationTool({
+      previewUrl: {
+        initial: "/",
+        previewMode: {
+          enable: "/api/draft-mode/enable",
+        },
+      },
+    }),
+  ],
 });

--- a/test/sanity-preview.test.ts
+++ b/test/sanity-preview.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const sanityConfig = readFileSync(
+  new URL("../src/sanity/sanity.config.ts", import.meta.url),
+  "utf8",
+);
+const draftModeRoute = readFileSync(
+  new URL("../src/app/api/draft-mode/enable/route.ts", import.meta.url),
+  "utf8",
+);
+const appLayout = readFileSync(
+  new URL("../src/app/layout.tsx", import.meta.url),
+  "utf8",
+);
+
+test("Sanity Studio presentation can enable website draft mode", () => {
+  assert.match(sanityConfig, /presentationTool/);
+  assert.match(sanityConfig, /enable:\s*"\/api\/draft-mode\/enable"/);
+  assert.match(draftModeRoute, /defineEnableDraftMode/);
+  assert.match(draftModeRoute, /SANITY_API_READ_TOKEN/);
+});
+
+test("root layout wires Sanity live preview for draft sessions", () => {
+  assert.match(appLayout, /SanityLive/);
+  assert.match(appLayout, /includeDrafts={isDraftMode}/);
+  assert.match(appLayout, /VisualEditing/);
+});


### PR DESCRIPTION
## Summary

- add Sanity Presentation draft-mode wiring for the embedded Studio
- switch Sanity data helpers to draft-aware Sanity Live fetches
- document the Vercel Preview staging flow and required read token
- add regression coverage for the preview route and layout wiring

## Validation

- pnpm lint
- pnpm test
- pnpm build
- pnpm typecheck
