### PR TITLE
ci: mirror workflow-lint and spellcheck from member-manager

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,11 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs on a branch/PR, but never cancel main.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   verify:
     name: Verify

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,19 @@
+name: Spell Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  spellcheck:
+    name: Spell Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Check spelling
+        uses: crate-ci/typos@v1.48.0

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -21,4 +21,7 @@ jobs:
         uses: raven-actions/actionlint@v2
       - name: Audit workflows with zizmor (advisory)
         # Advisory for now; promote to a hard gate once findings are triaged.
-        run: pipx run zizmor --no-progress .github/workflows || true
+        # continue-on-error (not `|| true`) keeps tool-crash failures visible
+        # in the step UI instead of silently swallowing them.
+        continue-on-error: true
+        run: pipx run zizmor --no-progress .github/workflows

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,24 @@
+name: Workflow Lint
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+jobs:
+  workflow-lint:
+    name: Workflow Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Lint GitHub Actions workflows
+        uses: raven-actions/actionlint@v2
+      - name: Audit workflows with zizmor (advisory)
+        # Advisory for now; promote to a hard gate once findings are triaged.
+        run: pipx run zizmor --no-progress .github/workflows || true

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,31 @@
+# Spell-check config for `typos` (crate-ci/typos).
+# This site has bilingual (English + German) legal pages, so the German
+# Impressum/Datenschutz prose is excluded wholesale. A small allowlist covers
+# other intentional non-English words/names. Prefer fixing real typos over
+# adding words here.
+
+[files]
+extend-exclude = [
+  "pnpm-lock.yaml",
+  "*.svg",
+  # German legal prose (Impressum / Datenschutz).
+  "src/views/footer/Imprint.tsx",
+  "src/views/footer/Privacy.tsx",
+]
+
+[default]
+extend-ignore-re = [
+  # Known copy bug (stray German "oder" merging two draft sentences) flagged
+  # separately for content review, not silenced as a legitimate word.
+  "to the broader community\\. oder The Marketing Department",
+]
+
+[default.extend-words]
+# LinkedIn-verified alumnus name (github.com/richardgaus), not "Gauss".
+Gaus = "Gaus"
+# "Dies Academicus" is the official name of the TUM ceremony, not a typo.
+Academicus = "Academicus"
+# German CSS comments (Subtile Elemente = "subtle elements", Fokus-Ring = "focus ring").
+Subtile = "Subtile"
+Elemente = "Elemente"
+Fokus = "Fokus"

--- a/src/components/apply/Milestones.tsx
+++ b/src/components/apply/Milestones.tsx
@@ -3,7 +3,7 @@ export default function Milestones() {
     {
       year: "2020",
       content: [
-        "Official Accrediation as a Student Initiative at TUM",
+        "Official Accreditation as a Student Initiative at TUM",
         "Development of a first concept for the initiative at the BusinessPlan-Seminar at UnternehmerTUM",
         "First Application Phase",
       ],

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -94,7 +94,7 @@
   --destructive: oklch(0.577 0.245 27.325); /* red for errors (stays standard) */
   --destructive-foreground: var(--color-white);
 
-  --border: var(--color-minimal-gray); /* Frame fo Inputs/Cards */
+  --border: var(--color-minimal-gray); /* Frame for Inputs/Cards */
   --input: var(--color-minimal-gray);
   --ring: var(--color-tumai-violet); /* Fokus-Ring */
 


### PR DESCRIPTION
## Summary

Brings this repo's CI closer to the conventions used in `member-manager`:

- `workflow-lint.yml`: `actionlint` (hard gate) + `zizmor` (advisory) on `.github/workflows/**` changes.
- `spellcheck.yml`: `crate-ci/typos` spell check on PRs, with a new `_typos.toml` excluding the German legal pages (Imprint/Privacy) and allowlisting a handful of intentional non-English words/names (see file for details).
- Added `concurrency`/`cancel-in-progress` to the `Verify` workflow so superseded pushes to a PR don't queue redundant runs (main is never cancelled).

Not mirrored: `member-manager`'s CodeQL / dependency-review / dependabot-auto-merge jobs, since those are already covered (in a more thorough form) by #162.

## Side fixes

Enabling the spellchecker surfaced two real typos, fixed here:

- `Accrediation` -> `Accreditation` in the milestones timeline copy.
- `Frame fo Inputs/Cards` -> `Frame for Inputs/Cards` in a CSS comment.

## Flagged for follow-up (not fixed here)

`src/data/community.tsx` has a stray German "oder" ("or") merging what look like two draft versions of the Marketing department description:

> "...to the broader community. oder The Marketing Department at TUM.ai gives our vision a voice and a look..."

Left as-is (with a scoped typos ignore) since picking the intended wording is a content decision, not a CI concern.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `actionlint .github/workflows/*.yml` locally
- [x] `typos` locally (clean)
- [ ] CI green on this PR
