### PR TITLE
fix(ci): set GH_REPO so dependabot automation works without checkout

### DIFF
--- a/.github/workflows/dependabot-maintenance.yml
+++ b/.github/workflows/dependabot-maintenance.yml
@@ -19,6 +19,11 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.schedule == '43 4 * * 1-5'
     runs-on: ubuntu-latest
 
+    # No checkout step in this job, so `gh` can't infer the repo from a git
+    # remote; GH_REPO tells it explicitly.
+    env:
+      GH_REPO: ${{ github.repository }}
+
     steps:
       # `author:app/dependabot` is the search-API qualifier for the same actor
       # dependabot-triage.yml matches via `user.login == 'dependabot[bot]'` on
@@ -39,6 +44,11 @@ jobs:
   merge:
     if: github.event_name == 'workflow_dispatch' || github.event.schedule == '17 * * * *'
     runs-on: ubuntu-latest
+
+    # No checkout step in this job, so `gh` can't infer the repo from a git
+    # remote; GH_REPO tells it explicitly.
+    env:
+      GH_REPO: ${{ github.repository }}
 
     steps:
       - name: Merge Dependabot PRs that are green and labeled for auto-merge

--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -18,6 +18,11 @@ jobs:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
 
+    # No checkout step in this job, so `gh` can't infer the repo from a git
+    # remote; GH_REPO tells it explicitly.
+    env:
+      GH_REPO: ${{ github.repository }}
+
     steps:
       - name: Ensure automation labels exist
         env:


### PR DESCRIPTION
## Summary

`dependabot-triage.yml` and `dependabot-maintenance.yml` (from #162) call `gh` without a checkout step, so `gh` has no git remote to infer the target repo from. Every run fails immediately:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

This has been failing the `triage` check on every Dependabot PR opened since #162 merged (currently #169-#181).

## Fix

Add `GH_REPO: ${{ github.repository }}` at the job level for the affected jobs, so `gh` targets the right repo without needing a checkout.

## Test plan

- [x] `actionlint .github/workflows/*.yml`
- [ ] CI green on this PR
- [ ] `triage` check passes on existing open Dependabot PRs once this merges (may need `workflow_dispatch` or a `synchronize` event to re-trigger)
